### PR TITLE
Add user content separation

### DIFF
--- a/twitter-replica-backend/src/models/post.model.js
+++ b/twitter-replica-backend/src/models/post.model.js
@@ -8,6 +8,10 @@ const postSchema = new mongoose.Schema({
     ref: 'User',
     require: true,
   },
+  creatorUsernamePrefix: {
+    type: String,
+    require: true,
+  },
 });
 
 mongoose.model('Post', postSchema);

--- a/twitter-replica-backend/src/models/user.model.js
+++ b/twitter-replica-backend/src/models/user.model.js
@@ -6,6 +6,7 @@ const authConfig = require('../configs/authConfig');
 const userSchema = new mongoose.Schema({
   email: { type: String, require: true, unique: true },
   username: { type: String, require: true, unique: true },
+  usernamePrefix: { type: String, require: true, unique: true },
   password: { type: String, require: true },
 });
 
@@ -13,7 +14,11 @@ userSchema.plugin(uniqueValidator, { message: 'is already taken.' });
 
 userSchema.methods.generateJWT = function generateJWT() {
   return jwt.sign(
-    { id: this._id, username: this.username },
+    {
+      id: this._id,
+      username: this.username,
+      usernamePrefix: this.usernamePrefix,
+    },
     authConfig.secret,
     {
       expiresIn: authConfig.expiration,

--- a/twitter-replica-backend/src/routes/api/index.js
+++ b/twitter-replica-backend/src/routes/api/index.js
@@ -1,7 +1,7 @@
 const router = require('express').Router();
 
 // Inject individual routes
-router.use('', require('./user'));
-router.use('/posts', require('./posts'));
+router.use('/', require('./user'));
+router.use('/user/:usernamePrefix/posts', require('./posts'));
 
 module.exports = router;

--- a/twitter-replica-backend/src/routes/api/posts.js
+++ b/twitter-replica-backend/src/routes/api/posts.js
@@ -1,5 +1,5 @@
 const asyncHandler = require('express-async-handler');
-const router = require('express').Router();
+const router = require('express').Router({ mergeParams: true });
 const mongoose = require('mongoose');
 const properties = require('../../properties');
 const uploadImage = require('../../configs/mediaConfig');
@@ -13,13 +13,16 @@ router.get(
     const pageSize = +req.query.pageSize;
     const currentPage = +req.query.currentPage;
     let posts;
-
     if (pageSize && typeof currentPage !== 'undefined') {
-      posts = await Post.find()
+      posts = await Post.find({
+        creatorUsernamePrefix: req.params.usernamePrefix,
+      })
         .skip(pageSize * currentPage)
         .limit(pageSize);
     } else {
-      posts = await Post.find();
+      posts = await Post.find({
+        creatorUsernamePrefix: req.params.usernamePrefix,
+      });
     }
     const totalPosts = await Post.estimatedDocumentCount();
     res.json({ posts, totalPostsCount: totalPosts }).send();
@@ -36,6 +39,7 @@ router.post(
       content: req.body.content,
       mediaPath: url + properties.mediaPath + req.file.filename,
       creatorId: req.userData.id,
+      creatorUsernamePrefix: req.userData.usernamePrefix,
     });
     const ret = await post.save();
     res.json(ret).send();
@@ -59,6 +63,7 @@ router.put(
       content: req.body.content,
       mediaPath: currentMedia,
       creatorId: req.userData.id,
+      creatorUsernamePrefix: req.userData.usernamePrefix,
     });
 
     const result = await Post.updateOne(

--- a/twitter-replica-ui/angular.json
+++ b/twitter-replica-ui/angular.json
@@ -198,6 +198,32 @@
           }
         }
       }
+    },
+    "twitter-user": {
+      "root": "libs/twitter-user",
+      "sourceRoot": "libs/twitter-user/src",
+      "projectType": "library",
+      "prefix": "twitter",
+      "architect": {
+        "test": {
+          "builder": "@angular-devkit/build-angular:karma",
+          "options": {
+            "main": "libs/twitter-user/src/test-setup.ts",
+            "tsConfig": "libs/twitter-user/tsconfig.spec.json",
+            "karmaConfig": "libs/twitter-user/karma.conf.js"
+          }
+        },
+        "lint": {
+          "builder": "@angular-devkit/build-angular:tslint",
+          "options": {
+            "tsConfig": [
+              "libs/twitter-user/tsconfig.lib.json",
+              "libs/twitter-user/tsconfig.spec.json"
+            ],
+            "exclude": ["**/node_modules/**"]
+          }
+        }
+      }
     }
   },
   "defaultProject": "twitter-replica"

--- a/twitter-replica-ui/apps/twitter-replica/src/app/app-routing.module.ts
+++ b/twitter-replica-ui/apps/twitter-replica/src/app/app-routing.module.ts
@@ -3,12 +3,15 @@ import { Routes, RouterModule } from '@angular/router';
 
 import { TwitterLoginRoutes, TwitterSignupRoutes } from '@twitter-replica/auth';
 import { TwitterPostRoutes } from '@twitter-replica/post';
+import { TwitterUserRoutes } from '@twitter-replica/user';
 
 const routes: Routes = [
-  { path: '', pathMatch: 'full', redirectTo: 'post' },
+  { path: '', pathMatch: 'full', redirectTo: 'login' },
   { path: 'login', children: TwitterLoginRoutes },
   { path: 'signup', children: TwitterSignupRoutes },
-  { path: 'post', children: TwitterPostRoutes },
+  { path: 'user/:username', children: TwitterUserRoutes },
+  { path: 'user/:username/post', children: TwitterPostRoutes },
+  // { path: '**', component:  USER DOES NOT EXISTS COMPONENT },
 ];
 
 @NgModule({

--- a/twitter-replica-ui/libs/twitter-core/src/lib/header/header.component.html
+++ b/twitter-replica-ui/libs/twitter-core/src/lib/header/header.component.html
@@ -1,7 +1,10 @@
 <mat-toolbar color="primary">
-  <span><a routerLink="/">My Posts</a></span>
+  <span><a [routerLink]="['/user', usernamePrefix]">My Posts</a></span>
   <span *ngIf="authStatus"
-    ><a mat-button routerLink="/post/create" routerLinkActive="mat-accent"
+    ><a
+      mat-button
+      [routerLink]="['/user', usernamePrefix, 'post', 'create']"
+      routerLinkActive="mat-accent"
       >Create Post</a
     ></span
   >

--- a/twitter-replica-ui/libs/twitter-core/src/lib/header/header.component.ts
+++ b/twitter-replica-ui/libs/twitter-core/src/lib/header/header.component.ts
@@ -9,7 +9,10 @@ import { Subscription } from 'rxjs';
 })
 export class HeaderComponent implements OnInit, OnDestroy {
   authStatus = false;
+  usernamePrefix: string;
   private authTokenSubs = new Subscription();
+  private usernamePrefixSubs = new Subscription();
+
   constructor(private readonly authService: AuthService) {}
 
   ngOnInit() {
@@ -19,6 +22,13 @@ export class HeaderComponent implements OnInit, OnDestroy {
       .subscribe((hasAuthToken: boolean) => {
         this.authStatus = hasAuthToken;
       });
+
+    this.usernamePrefix = this.authService.getUsernamePrefix();
+    this.usernamePrefixSubs = this.authService
+      .getUsernamePrefixListener()
+      .subscribe((prefix: string) => {
+        this.usernamePrefix = prefix;
+      });
   }
 
   onLogOut() {
@@ -27,5 +37,6 @@ export class HeaderComponent implements OnInit, OnDestroy {
 
   ngOnDestroy() {
     this.authTokenSubs.unsubscribe();
+    this.usernamePrefixSubs.unsubscribe();
   }
 }

--- a/twitter-replica-ui/libs/twitter-core/src/lib/http-services/index.ts
+++ b/twitter-replica-ui/libs/twitter-core/src/lib/http-services/index.ts
@@ -1,3 +1,4 @@
 export * from './post.service';
 export * from './auth.service';
+export * from './user.service';
 export * from './urls';

--- a/twitter-replica-ui/libs/twitter-core/src/lib/http-services/urls.ts
+++ b/twitter-replica-ui/libs/twitter-core/src/lib/http-services/urls.ts
@@ -11,9 +11,12 @@ export namespace URL {
   export const AUTH_SIGNUP = `${API}${SINGUP}`;
   export const AUTH_LOGIN = `${API}${LOGIN}`;
 
+  // USERS
+  export const GET_USER = `${API}/user/`;
+
   // POSTS
-  export const GET_POSTS = `${API}/posts`;
-  export const CREATE_POST = `${API}/posts`;
-  export const DELETE_POST = `${API}/posts/`;
-  export const UPDATE_POST = `${API}/posts/`;
+  export const GET_POSTS = `/posts`;
+  export const CREATE_POST = `/posts`;
+  export const DELETE_POST = `/posts/`;
+  export const UPDATE_POST = `/posts/`;
 }

--- a/twitter-replica-ui/libs/twitter-core/src/lib/http-services/user.service.ts
+++ b/twitter-replica-ui/libs/twitter-core/src/lib/http-services/user.service.ts
@@ -1,0 +1,40 @@
+import { Injectable } from '@angular/core';
+import { HttpClient } from '@angular/common/http';
+
+import { UserModel } from '../models';
+import { URL } from './urls';
+import { Subject } from 'rxjs';
+
+@Injectable({
+  providedIn: 'root',
+})
+export class UserService {
+  currentUser: UserModel = {
+    coverImage:
+      'http://localhost:3333/Users/i521368/myProjects/Twitter-replica/twitter-replica-backend/media/unknown_background.jpg',
+    avatar:
+      'http://localhost:3333/Users/i521368/myProjects/Twitter-replica/twitter-replica-backend/media/unknown_user.png',
+    name: 'Default User',
+    username: '@DefaultUser',
+    bio: '',
+  };
+  private currentUserListener = new Subject<UserModel>();
+
+  constructor(private readonly httpClient: HttpClient) {}
+
+  getUser(usernamePrefix: string) {
+    return this.httpClient
+      .get<UserModel>(`${URL.GET_USER}/${usernamePrefix}`)
+      .subscribe((user: UserModel) => {
+        this.currentUser = user;
+        this.currentUserListener.next(this.currentUser);
+      });
+  }
+
+  getCurrentUser() {
+    return this.currentUser;
+  }
+  getCurrentUserListener() {
+    return this.currentUserListener.asObservable();
+  }
+}

--- a/twitter-replica-ui/libs/twitter-core/src/lib/models/auth/backend-login.model.ts
+++ b/twitter-replica-ui/libs/twitter-core/src/lib/models/auth/backend-login.model.ts
@@ -1,4 +1,0 @@
-export interface BackendLogin {
-  token: string;
-  userId: string;
-}

--- a/twitter-replica-ui/libs/twitter-core/src/lib/models/auth/index.ts
+++ b/twitter-replica-ui/libs/twitter-core/src/lib/models/auth/index.ts
@@ -1,4 +1,4 @@
 export * from './signup.model';
 export * from './login.model';
-export * from './backend-signup.model';
-export * from './backend-login.model';
+export * from './signup-response.model';
+export * from './login-response.model';

--- a/twitter-replica-ui/libs/twitter-core/src/lib/models/auth/login-response.model.ts
+++ b/twitter-replica-ui/libs/twitter-core/src/lib/models/auth/login-response.model.ts
@@ -1,0 +1,5 @@
+export interface LoginResponseModel {
+  token: string;
+  userId: string;
+  usernamePrefix: string;
+}

--- a/twitter-replica-ui/libs/twitter-core/src/lib/models/auth/signup-response.model.ts
+++ b/twitter-replica-ui/libs/twitter-core/src/lib/models/auth/signup-response.model.ts
@@ -1,6 +1,7 @@
-export interface BackendSignupModel {
+export interface SignupResponseModel {
   _id: string;
   email: string;
   username: string;
+  usernamePrefix: string;
   password: string;
 }

--- a/twitter-replica-ui/libs/twitter-core/src/lib/models/index.ts
+++ b/twitter-replica-ui/libs/twitter-core/src/lib/models/index.ts
@@ -1,2 +1,3 @@
 export * from './auth';
 export * from './posts';
+export * from './users';

--- a/twitter-replica-ui/libs/twitter-core/src/lib/models/posts/backend-post.model.ts
+++ b/twitter-replica-ui/libs/twitter-core/src/lib/models/posts/backend-post.model.ts
@@ -4,4 +4,5 @@ export interface BackendPostModel {
   content: string;
   mediaPath: string;
   creatorId: string;
+  creatorUsernamePrefix: string;
 }

--- a/twitter-replica-ui/libs/twitter-core/src/lib/models/posts/post.model.ts
+++ b/twitter-replica-ui/libs/twitter-core/src/lib/models/posts/post.model.ts
@@ -4,4 +4,5 @@ export interface PostModel {
   content: string;
   mediaPath: string;
   creatorId: string;
+  creatorUsernamePrefix: string;
 }

--- a/twitter-replica-ui/libs/twitter-core/src/lib/models/users/index.ts
+++ b/twitter-replica-ui/libs/twitter-core/src/lib/models/users/index.ts
@@ -1,0 +1,1 @@
+export * from './user.model';

--- a/twitter-replica-ui/libs/twitter-core/src/lib/models/users/user.model.ts
+++ b/twitter-replica-ui/libs/twitter-core/src/lib/models/users/user.model.ts
@@ -1,0 +1,7 @@
+export interface UserModel {
+  coverImage: string;
+  avatar: string;
+  bio: string;
+  name: string;
+  username: string;
+}

--- a/twitter-replica-ui/libs/twitter-post/src/lib/post-list/post-list.component.html
+++ b/twitter-replica-ui/libs/twitter-post/src/lib/post-list/post-list.component.html
@@ -1,18 +1,14 @@
 <mat-card class="post" *ngFor="let post of posts">
   <mat-card-header>
     <div mat-card-avatar>
-      <img
-        mat-card-avatar
-        src="https://material.angular.io/assets/img/examples/shiba1.jpg"
-        alt="Shiba"
-      />
+      <img mat-card-avatar [src]="currentUser.avatar" alt="No avatar image" />
     </div>
-    <mat-card-title>Shiba Inu</mat-card-title>
-    <mat-card-subtitle>Dog Breed</mat-card-subtitle>
+    <mat-card-title>{{ currentUser.name }}</mat-card-title>
+    <mat-card-subtitle>{{ currentUser.username }}</mat-card-subtitle>
     <span class="fill-remaining-space"></span>
     <!-- <post-list-menu></post-list-menu> -->
     <button
-      mat-mini-fab
+      mat-icon-button
       color="primary"
       [matMenuTriggerFor]="menu"
       aria-label="Post list menu actions"
@@ -21,7 +17,9 @@
       <mat-icon *ngIf="authStatus && userId == post.creatorId">menu</mat-icon>
     </button>
     <mat-menu #menu="matMenu">
-      <a mat-menu-item [routerLink]="['/post/edit', post.id]"
+      <a
+        mat-menu-item
+        [routerLink]="['/user', usernamePrefix, 'post', 'edit', post.id]"
         ><mat-icon>edit</mat-icon><span>EDIT</span></a
       >
 

--- a/twitter-replica-ui/libs/twitter-post/src/lib/twitter-post.module.ts
+++ b/twitter-replica-ui/libs/twitter-post/src/lib/twitter-post.module.ts
@@ -16,10 +16,10 @@ import { TwitterPostCreateComponent } from './post-create/post-create.component'
 import { TwitterPostListComponent } from './post-list/post-list.component';
 
 export const TwitterPostRoutes: Route[] = [
-  {
-    path: '',
-    component: TwitterPostListComponent,
-  },
+  // {
+  //   path: '',
+  //   component: TwitterPostListComponent,
+  // },
   {
     path: 'create',
     component: TwitterPostCreateComponent,

--- a/twitter-replica-ui/libs/twitter-user/README.md
+++ b/twitter-replica-ui/libs/twitter-user/README.md
@@ -1,0 +1,7 @@
+## Posts
+
+Module containing elements for interacting with user content.
+
+## Running unit tests
+
+Run `ng test twitter-post` to execute the unit tests.

--- a/twitter-replica-ui/libs/twitter-user/karma.conf.js
+++ b/twitter-replica-ui/libs/twitter-user/karma.conf.js
@@ -1,0 +1,31 @@
+// Karma configuration file, see link for more information
+// https://karma-runner.github.io/1.0/config/configuration-file.html
+
+module.exports = function(config) {
+  config.set({
+    basePath: '',
+    frameworks: ['jasmine', '@angular-devkit/build-angular'],
+    plugins: [
+      require('karma-jasmine'),
+      require('karma-chrome-launcher'),
+      require('karma-jasmine-html-reporter'),
+      require('karma-coverage-istanbul-reporter'),
+      require('@angular-devkit/build-angular/plugins/karma')
+    ],
+    client: {
+      clearContext: false // leave Jasmine Spec Runner output visible in browser
+    },
+    coverageIstanbulReporter: {
+      dir: require('path').join(__dirname, '../../coverage'),
+      reports: ['html', 'lcovonly'],
+      fixWebpackSourcePaths: true
+    },
+    reporters: ['progress', 'kjhtml'],
+    port: 9876,
+    colors: true,
+    logLevel: config.LOG_INFO,
+    autoWatch: true,
+    browsers: ['Chrome'],
+    singleRun: false
+  });
+};

--- a/twitter-replica-ui/libs/twitter-user/src/index.ts
+++ b/twitter-replica-ui/libs/twitter-user/src/index.ts
@@ -1,0 +1,1 @@
+export * from './lib/twitter-user.module';

--- a/twitter-replica-ui/libs/twitter-user/src/lib/twitter-user.module.spec.ts
+++ b/twitter-replica-ui/libs/twitter-user/src/lib/twitter-user.module.spec.ts
@@ -1,0 +1,14 @@
+import { async, TestBed } from '@angular/core/testing';
+import { TwitterUserModule } from './twitter-user.module';
+
+describe('TwitterUserModule', () => {
+  beforeEach(async(() => {
+    TestBed.configureTestingModule({
+      imports: [TwitterUserModule],
+    }).compileComponents();
+  }));
+
+  it('should create', () => {
+    expect(TwitterUserModule).toBeDefined();
+  });
+});

--- a/twitter-replica-ui/libs/twitter-user/src/lib/twitter-user.module.ts
+++ b/twitter-replica-ui/libs/twitter-user/src/lib/twitter-user.module.ts
@@ -1,0 +1,36 @@
+import { NgModule } from '@angular/core';
+import { CommonModule } from '@angular/common';
+import { RouterModule, Route } from '@angular/router';
+import { MatInputModule } from '@angular/material/input';
+import { MatCardModule } from '@angular/material/card';
+import { MatButtonModule } from '@angular/material/button';
+import { MatExpansionModule } from '@angular/material/expansion';
+import { MatPaginatorModule } from '@angular/material/paginator';
+import { MatIconModule } from '@angular/material/icon';
+
+import { TwitterUserHomepageComponent } from './user-homepage/user-homepage.component';
+import { TwitterPostModule } from '@twitter-replica/post';
+
+export const TwitterUserRoutes: Route[] = [
+  {
+    path: '',
+    component: TwitterUserHomepageComponent,
+  },
+];
+
+@NgModule({
+  imports: [
+    CommonModule,
+    RouterModule,
+    TwitterPostModule,
+    MatInputModule,
+    MatCardModule,
+    MatButtonModule,
+    MatIconModule,
+    MatExpansionModule,
+    MatPaginatorModule,
+  ],
+  declarations: [TwitterUserHomepageComponent],
+  exports: [TwitterUserHomepageComponent],
+})
+export class TwitterUserModule {}

--- a/twitter-replica-ui/libs/twitter-user/src/lib/user-homepage/user-homepage.component.html
+++ b/twitter-replica-ui/libs/twitter-user/src/lib/user-homepage/user-homepage.component.html
@@ -1,0 +1,30 @@
+<mat-card class="banner-card">
+  <img
+    class="cover-image"
+    mat-card-image
+    [src]="currentUser.coverImage"
+    alt="No cover image available"
+  />
+  <mat-card-header>
+    <div mat-card-avatar class="avatar">
+      <img
+        class="avatar"
+        mat-card-avatar
+        [src]="currentUser.avatar"
+        alt="No avatar image available"
+      />
+    </div>
+    <span class="fill-remaining-space"></span>
+    <div>
+      <button mat-stroked-button color="primary">Set up profile</button>
+    </div>
+    <mat-card-title>{{ currentUser.name }} </mat-card-title>
+    <mat-card-subtitle>{{ currentUser.username }}</mat-card-subtitle>
+  </mat-card-header>
+  <mat-card-content>
+    <p>
+      {{ currentUser.bio }}
+    </p>
+  </mat-card-content>
+</mat-card>
+<twitter-post-list></twitter-post-list>

--- a/twitter-replica-ui/libs/twitter-user/src/lib/user-homepage/user-homepage.component.scss
+++ b/twitter-replica-ui/libs/twitter-user/src/lib/user-homepage/user-homepage.component.scss
@@ -1,0 +1,15 @@
+.banner-card {
+  width: 400px;
+  margin: 0 auto;
+  width: 50%;
+}
+
+.avatar {
+  background-size: cover;
+  width: 120px;
+  height: 120px;
+}
+
+.fill-remaining-space {
+  flex: 1 1 auto;
+}

--- a/twitter-replica-ui/libs/twitter-user/src/lib/user-homepage/user-homepage.component.spec.ts
+++ b/twitter-replica-ui/libs/twitter-user/src/lib/user-homepage/user-homepage.component.spec.ts
@@ -1,0 +1,24 @@
+import { async, ComponentFixture, TestBed } from '@angular/core/testing';
+
+import { TwitterUserHomepageComponent } from './user-homepage.component';
+
+describe('TwitterUserHomepageComponent', () => {
+  let component: TwitterUserHomepageComponent;
+  let fixture: ComponentFixture<TwitterUserHomepageComponent>;
+
+  beforeEach(async(() => {
+    TestBed.configureTestingModule({
+      declarations: [TwitterUserHomepageComponent],
+    }).compileComponents();
+  }));
+
+  beforeEach(() => {
+    fixture = TestBed.createComponent(TwitterUserHomepageComponent);
+    component = fixture.componentInstance;
+    fixture.detectChanges();
+  });
+
+  it('should create', () => {
+    expect(component).toBeTruthy();
+  });
+});

--- a/twitter-replica-ui/libs/twitter-user/src/lib/user-homepage/user-homepage.component.ts
+++ b/twitter-replica-ui/libs/twitter-user/src/lib/user-homepage/user-homepage.component.ts
@@ -1,0 +1,39 @@
+import { Component, OnInit, OnDestroy } from '@angular/core';
+import { ActivatedRoute, ParamMap } from '@angular/router';
+
+import { UserModel, UserService, PostService } from 'libs/twitter-core/src';
+import { Subscription } from 'rxjs';
+
+@Component({
+  selector: 'twitter-user-homepage',
+  templateUrl: './user-homepage.component.html',
+  styleUrls: ['./user-homepage.component.scss'],
+})
+export class TwitterUserHomepageComponent implements OnInit, OnDestroy {
+  usernamePrefix: string;
+  currentUser: UserModel;
+  currentUserSubs = new Subscription();
+
+  constructor(
+    private readonly userService: UserService,
+    private readonly postService: PostService,
+    private readonly route: ActivatedRoute
+  ) {}
+
+  ngOnInit() {
+    this.currentUser = this.userService.getCurrentUser();
+    this.currentUserSubs = this.userService
+      .getCurrentUserListener()
+      .subscribe((user: UserModel) => {
+        this.currentUser = user;
+      });
+    // this.route.paramMap.subscribe((paramMap: ParamMap) => {
+    //   this.usernamePrefix = paramMap.get('username');
+    //   this.userService.getUser(this.usernamePrefix);
+    // });
+  }
+
+  ngOnDestroy() {
+    this.currentUserSubs.unsubscribe();
+  }
+}

--- a/twitter-replica-ui/libs/twitter-user/src/test-setup.ts
+++ b/twitter-replica-ui/libs/twitter-user/src/test-setup.ts
@@ -1,0 +1,22 @@
+// This file is required by karma.conf.js and loads recursively all the .spec and framework files
+
+import 'core-js/es7/reflect';
+import 'zone.js/dist/zone';
+import 'zone.js/dist/zone-testing';
+import { getTestBed } from '@angular/core/testing';
+import {
+  BrowserDynamicTestingModule,
+  platformBrowserDynamicTesting
+} from '@angular/platform-browser-dynamic/testing';
+
+declare const require: any;
+
+// First, initialize the Angular testing environment.
+getTestBed().initTestEnvironment(
+  BrowserDynamicTestingModule,
+  platformBrowserDynamicTesting()
+);
+// Then we find all the tests.
+const context = require.context('./', true, /\.spec\.ts$/);
+// And load the modules.
+context.keys().map(context);

--- a/twitter-replica-ui/libs/twitter-user/tsconfig.lib.json
+++ b/twitter-replica-ui/libs/twitter-user/tsconfig.lib.json
@@ -1,0 +1,6 @@
+  
+{
+  "extends": "../tsconfig.lib.json",
+  "include": ["**/*.ts"],
+  "exclude": ["src/test.ts", "**/*.spec.ts"]
+}

--- a/twitter-replica-ui/libs/twitter-user/tsconfig.spec.json
+++ b/twitter-replica-ui/libs/twitter-user/tsconfig.spec.json
@@ -1,0 +1,5 @@
+{
+  "extends": "../tsconfig.spec.json",
+  "files": ["src/test-setup.ts"],
+  "include": ["**/*.ts", "**/*.spec.ts", "**/*.d.ts"]
+}

--- a/twitter-replica-ui/libs/twitter-user/tslint.json
+++ b/twitter-replica-ui/libs/twitter-user/tslint.json
@@ -1,0 +1,3 @@
+{
+  "extends": "../tslint.json"
+}

--- a/twitter-replica-ui/tsconfig.json
+++ b/twitter-replica-ui/tsconfig.json
@@ -16,7 +16,8 @@
     "paths": {
       "@twitter-replica/core": ["libs/twitter-core/src/index.ts"],
       "@twitter-replica/post": ["libs/twitter-post/src/index.ts"],
-      "@twitter-replica/auth": ["libs/twitter-auth/src/index.ts"]
+      "@twitter-replica/auth": ["libs/twitter-auth/src/index.ts"],
+      "@twitter-replica/user": ["libs/twitter-user/src/index.ts"]
     }
   },
   "angularCompilerOptions": {


### PR DESCRIPTION
- Add new consumable module `Twitter-User`.
- Add separation of posts by user.
- Add `usernamePrefix` for `userId` representation for the client-side URL.
- Attach `usernamePrefix` to `Post` model on the server-side.
- Add `usernamePrefix` to token structure and persist it in local-storage.

The decision was made to avoid usage of `userId` in the client routing, which is a driving factor for the user content fetching.