### PR TITLE
feature/ Add object level caching using Redis

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -45,3 +45,6 @@ testem.log
 # System Files
 .DS_Store
 Thumbs.db
+
+# Ignore redis binary dump (dump.rdb) files
+*.rdb

--- a/twitter-replica-backend/.gitignore
+++ b/twitter-replica-backend/.gitignore
@@ -50,3 +50,7 @@ testem.log
 # System Files
 .DS_Store
 Thumbs.db
+
+
+# Ignore redis binary dump (dump.rdb) files
+*.rdb

--- a/twitter-replica-backend/package-lock.json
+++ b/twitter-replica-backend/package-lock.json
@@ -321,9 +321,9 @@
       }
     },
     "bluebird": {
-      "version": "3.5.1",
-      "resolved": "https://registry.npmjs.org/bluebird/-/bluebird-3.5.1.tgz",
-      "integrity": "sha512-MKiLiV+I1AA596t9w1sQJ8jkiSr5+ZKi0WKrYGUn6d1Fx+Ij4tIj+m2WMQSGczs5jZVxV339chE8iwk6F64wjA=="
+      "version": "3.7.2",
+      "resolved": "https://registry.npmjs.org/bluebird/-/bluebird-3.7.2.tgz",
+      "integrity": "sha512-XpNj6GDQzdfW+r2Wnn7xiSAd7TM3jzkxGXBGTtWKuSXv1xUV+azxAm8jdWZN06QTQk+2N2XB9jRDkvbmQmcRtg=="
     },
     "body-parser": {
       "version": "1.19.0",
@@ -2591,6 +2591,11 @@
         "sliced": "1.0.1"
       },
       "dependencies": {
+        "bluebird": {
+          "version": "3.5.1",
+          "resolved": "https://registry.npmjs.org/bluebird/-/bluebird-3.5.1.tgz",
+          "integrity": "sha512-MKiLiV+I1AA596t9w1sQJ8jkiSr5+ZKi0WKrYGUn6d1Fx+Ij4tIj+m2WMQSGczs5jZVxV339chE8iwk6F64wjA=="
+        },
         "debug": {
           "version": "3.1.0",
           "resolved": "https://registry.npmjs.org/debug/-/debug-3.1.0.tgz",
@@ -3041,6 +3046,11 @@
       "integrity": "sha512-7PiHtLll5LdnKIMw100I+8xJXR5gW2QwWYkT6iJva0bXitZKa/XMrSbdmg3r2Xnaidz9Qumd0VPaMrZlF9V9sA==",
       "dev": true
     },
+    "promise-queue": {
+      "version": "2.2.5",
+      "resolved": "https://registry.npmjs.org/promise-queue/-/promise-queue-2.2.5.tgz",
+      "integrity": "sha1-L29ffA9tCBCelnZZx5uIqe1ek7Q="
+    },
     "proxy-addr": {
       "version": "2.0.6",
       "resolved": "https://registry.npmjs.org/proxy-addr/-/proxy-addr-2.0.6.tgz",
@@ -3173,6 +3183,43 @@
       "dev": true,
       "requires": {
         "picomatch": "^2.0.7"
+      }
+    },
+    "redis": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/redis/-/redis-3.0.2.tgz",
+      "integrity": "sha512-PNhLCrjU6vKVuMOyFu7oSP296mwBkcE6lrAjruBYG5LgdSqtRBoVQIylrMyVZD/lkF24RSNNatzvYag6HRBHjQ==",
+      "requires": {
+        "denque": "^1.4.1",
+        "redis-commands": "^1.5.0",
+        "redis-errors": "^1.2.0",
+        "redis-parser": "^3.0.0"
+      }
+    },
+    "redis-commands": {
+      "version": "1.6.0",
+      "resolved": "https://registry.npmjs.org/redis-commands/-/redis-commands-1.6.0.tgz",
+      "integrity": "sha512-2jnZ0IkjZxvguITjFTrGiLyzQZcTvaw8DAaCXxZq/dsHXz7KfMQ3OUJy7Tz9vnRtZRVz6VRCPDvruvU8Ts44wQ=="
+    },
+    "redis-errors": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/redis-errors/-/redis-errors-1.2.0.tgz",
+      "integrity": "sha1-62LSrbFeTq9GEMBK/hUpOEJQq60="
+    },
+    "redis-parser": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/redis-parser/-/redis-parser-3.0.0.tgz",
+      "integrity": "sha1-tm2CjNyv5rS4pCin3vTGvKwxyLQ=",
+      "requires": {
+        "redis-errors": "^1.0.0"
+      }
+    },
+    "redis-server": {
+      "version": "1.2.2",
+      "resolved": "https://registry.npmjs.org/redis-server/-/redis-server-1.2.2.tgz",
+      "integrity": "sha512-pOaSIeSMVFkEFIuaMtpQ3TOr3uI4sUmEHm4ofGks5vTPRseHUszxyIlC70IFjUR9qSeH8o/ARZEM8dqcJmgGJw==",
+      "requires": {
+        "promise-queue": "^2.2.5"
       }
     },
     "regexp-clone": {

--- a/twitter-replica-backend/package.json
+++ b/twitter-replica-backend/package.json
@@ -14,6 +14,7 @@
   "dependencies": {
     "aws-sdk": "2.686.0",
     "bcryptjs": "^2.4.3",
+    "bluebird": "3.7.2",
     "body-parser": "^1.19.0",
     "cors": "^2.8.5",
     "dotenv": "^8.2.0",
@@ -24,7 +25,9 @@
     "mongoose": "^5.9.6",
     "mongoose-unique-validator": "^2.0.3",
     "multer": "^1.4.2",
-    "multer-s3": "2.9.0"
+    "multer-s3": "2.9.0",
+    "redis": "3.0.2",
+    "redis-server": "1.2.2"
   },
   "devDependencies": {
     "eslint": "^6.8.0",

--- a/twitter-replica-backend/src/cache/cache.js
+++ b/twitter-replica-backend/src/cache/cache.js
@@ -1,0 +1,3 @@
+cache = require('./methods');
+
+module.exports = cache;

--- a/twitter-replica-backend/src/cache/constants.js
+++ b/twitter-replica-backend/src/cache/constants.js
@@ -1,0 +1,5 @@
+const USER_KEY_DELIM = ':';
+const FOLLOW_KEY_DELIM = ':';
+
+exports.USER_KEY_DELIM = USER_KEY_DELIM;
+exports.FOLLOW_KEY_DELIM = FOLLOW_KEY_DELIM;

--- a/twitter-replica-backend/src/cache/methods/follow.methods.js
+++ b/twitter-replica-backend/src/cache/methods/follow.methods.js
@@ -1,0 +1,52 @@
+const redisClient = require('../redis.client');
+const constants = require('../constants');
+
+exports.getFollowingSet = (usernamePrefix) => {
+  return `following${constants.FOLLOW_KEY_DELIM}${usernamePrefix}`;
+};
+
+exports.getFollowerSet = (usernamePrefix) => {
+  return `followers${constants.FOLLOW_KEY_DELIM}${usernamePrefix}`;
+};
+
+exports.addFollowing = async (user, timestamp, userToFollowData) => {
+  const followingSet = this.getFollowingSet(user);
+  await redisClient.zaddAsync(followingSet, timestamp, userToFollowData);
+};
+
+exports.addFollower = async (user, timestamp, followerData) => {
+  const followerSet = this.getFollowerSet(user);
+  await redisClient.zaddAsync(followerSet, timestamp, followerData);
+};
+
+exports.removeFollowing = async (user, userToRemoveData) => {
+  const followingSet = this.getFollowingSet(user);
+  await redisClient.zremAsync(followingSet, userToRemoveData);
+};
+
+exports.removeFollower = async (user, userToRemoveData) => {
+  const followerSet = this.getFollowerSet(user);
+  await redisClient.zremAsync(followerSet, userToRemoveData);
+};
+
+exports.getFollowingUsers = async (user) => {
+  const followingSet = this.getFollowingSet(user);
+  const followingSetExists = await redisClient.existsAsync(followingSet);
+  let followingUsers = null;
+  if (followingSetExists) {
+    followingUsers = await redisClient.zrangeAsync([followingSet, 0, -1]);
+    followingUsers = followingUsers.map((following) => JSON.parse(following));
+  }
+  return followingUsers;
+};
+
+exports.getFollowers = async (user) => {
+  const followerSet = this.getFollowerSet(user);
+  const followerSetExists = await redisClient.existsAsync(followerSet);
+  let followers = null;
+  if (followerSetExists) {
+    followers = await redisClient.zrangeAsync([followerSet, 0, -1]);
+    followers = followers.map((follower) => JSON.parse(follower));
+  }
+  return followers;
+};

--- a/twitter-replica-backend/src/cache/methods/index.js
+++ b/twitter-replica-backend/src/cache/methods/index.js
@@ -1,0 +1,2 @@
+exports.user = require('./user.methods');
+exports.follow = require('./follow.methods');

--- a/twitter-replica-backend/src/cache/methods/user.methods.js
+++ b/twitter-replica-backend/src/cache/methods/user.methods.js
@@ -1,0 +1,41 @@
+const redisClient = require('../redis.client');
+const constants = require('../constants');
+
+exports.getKey = (usernamePrefix) => {
+  return 'user' + constants.USER_KEY_DELIM + usernamePrefix;
+};
+
+exports.getUser = async (usernamePrefix) => {
+  const userKey = this.getKey(usernamePrefix);
+  const userExists = await redisClient.existsAsync(userKey);
+  let user = null;
+  if (userExists) {
+    user = await redisClient.hgetallAsync(userKey);
+  }
+  return user;
+};
+
+exports.setUser = async (usernamePrefix, user) => {
+  const userKey = this.getKey(usernamePrefix);
+
+  const userData = {
+    _id: user.id,
+    email: user.email,
+    username: user.username,
+    usernamePrefix: user.usernamePrefix,
+    password: user.password,
+    name: user.name,
+    bio: user.bio,
+    avatar: user.avatar,
+    coverImage: user.coverImage,
+  };
+
+  const properties = Object.entries(userData);
+  const flattenProperties = properties.flat();
+  await redisClient.hsetAsync(userKey, flattenProperties);
+};
+
+exports.deleteUser = async (usernamePrefix) => {
+  const userKey = this.getKey(usernamePrefix);
+  await redisClient.delAsync(userKey);
+};

--- a/twitter-replica-backend/src/cache/redis.client.js
+++ b/twitter-replica-backend/src/cache/redis.client.js
@@ -1,0 +1,11 @@
+var Promise = require('bluebird');
+var redis = Promise.promisifyAll(require('redis')).createClient();
+
+redis.on('connect', function () {
+  console.log('Redis client is online');
+});
+redis.on('error', function (err) {
+  console.log('Could not start Redis client, Error ' + err);
+});
+
+module.exports = redis;

--- a/twitter-replica-backend/src/main.js
+++ b/twitter-replica-backend/src/main.js
@@ -1,6 +1,7 @@
 require('dotenv').config();
 const path = require('path');
 const express = require('express');
+const RedisServer = require('redis-server');
 const cors = require('cors');
 const bodyParser = require('body-parser');
 const mongoose = require('mongoose');
@@ -8,6 +9,7 @@ const mongoConfig = require('./configs/database.config');
 require('./models/post.model');
 require('./models/user.model');
 const routes = require('./routes');
+const cache = require('./cache/cache');
 
 async function bootstrap() {
   const isProduction = process.env.NODE_ENV === 'production';
@@ -15,6 +17,8 @@ async function bootstrap() {
   const app = (module.exports = express());
 
   const port = process.env.PORT || 3333;
+  const redisPort = process.env.REDIS_PORT || 6379;
+
   app.use(cors());
   app.use(bodyParser.json());
 
@@ -30,6 +34,15 @@ async function bootstrap() {
       console.error('Connection to DB failed!');
     }
   }
+  // Start Redis server
+  const server = new RedisServer(redisPort);
+  server.open((err) => {
+    if (err === null) {
+      console.log('Connected to the Redis server');
+    } else {
+      console.log('Could not connect to the Redis server');
+    }
+  });
 
   // Inject routes
   app.use(routes);

--- a/twitter-replica-backend/src/models/user.model.js
+++ b/twitter-replica-backend/src/models/user.model.js
@@ -14,14 +14,20 @@ const userSchema = new mongoose.Schema({
   coverImage: { type: String, require: true },
   following: [
     {
-      type: mongoose.Schema.Types.ObjectId,
-      ref: 'User',
+      userId: {
+        type: mongoose.Schema.Types.ObjectId,
+        ref: 'User',
+      },
+      followTime: { type: Number },
     },
   ],
   followers: [
     {
-      type: mongoose.Schema.Types.ObjectId,
-      ref: 'User',
+      userId: {
+        type: mongoose.Schema.Types.ObjectId,
+        ref: 'User',
+      },
+      followTime: { type: Number },
     },
   ],
 });

--- a/twitter-replica-ui/libs/twitter-core/src/lib/http-services/fan-out.service.ts
+++ b/twitter-replica-ui/libs/twitter-core/src/lib/http-services/fan-out.service.ts
@@ -10,52 +10,33 @@ import { FollowModel } from '../models';
 })
 export class FanOutService {
   constructor(private readonly httpClient: HttpClient) {}
-  followingUsers: FollowModel[] = [];
-  followers: FollowModel[] = [];
-  cachedFollowingUsers = false;
-  cachedFollowers = false;
 
   // Subjects
   private followingUsersListener = new Subject<FollowModel[]>();
   private followersListener = new Subject<FollowModel[]>();
 
   getFollowingUsers() {
-    if (this.cachedFollowingUsers) {
-      this.followingUsersListener.next(this.followingUsers);
-    } else {
-      this.httpClient
-        .get<FollowModel[]>(`${URL.FOLLOWING_USERS}`)
-        .subscribe((usersToFollow: FollowModel[]) => {
-          this.cachedFollowingUsers = true;
-          this.followingUsers = cloneDeep(usersToFollow);
-          this.followingUsersListener.next(this.followingUsers);
-        });
-    }
+    this.httpClient
+      .get<FollowModel[]>(`${URL.FOLLOWING_USERS}`)
+      .subscribe((usersToFollow: FollowModel[]) => {
+        this.followingUsersListener.next(usersToFollow);
+      });
   }
 
   getFollowers() {
-    if (this.cachedFollowers) {
-      this.followersListener.next(this.followers);
-    } else {
-      this.httpClient
-        .get<FollowModel[]>(`${URL.FOLLOWER_USERS}`)
-        .subscribe((followers: FollowModel[]) => {
-          this.cachedFollowers = true;
-          this.followers = cloneDeep(followers);
-          this.followersListener.next(this.followers);
-        });
-    }
+    this.httpClient
+      .get<FollowModel[]>(`${URL.FOLLOWER_USERS}`)
+      .subscribe((followers: FollowModel[]) => {
+        this.followersListener.next(followers);
+      });
   }
 
   followUser(usernamePrefixToFollow: string) {
     this.httpClient
-      .post<FollowModel>(`${URL.FOLLOW_USER}`, {
+      .post(`${URL.FOLLOW_USER}`, {
         usernamePrefix: usernamePrefixToFollow,
       })
-      .subscribe((user: FollowModel) => {
-        this.followingUsers.unshift(user);
-        this.followingUsersListener.next(this.followingUsers);
-      });
+      .subscribe(() => {});
   }
 
   unfollowUser(usernamePrefixToFollow: string) {
@@ -63,15 +44,7 @@ export class FanOutService {
       .post(`${URL.UNFOLLOW_USER}`, {
         usernamePrefix: usernamePrefixToFollow,
       })
-      .subscribe(() => {
-        const userIndex = this.followingUsers.findIndex(
-          (user: FollowModel) => user.usernamePrefix === usernamePrefixToFollow
-        );
-        if (userIndex > -1) {
-          this.followingUsers.splice(userIndex, 1);
-        }
-        this.followingUsersListener.next(this.followingUsers);
-      });
+      .subscribe(() => {});
   }
 
   getFollowingUsersListener() {


### PR DESCRIPTION
Add object-level caching for the users and the list of users they follow.

The cache is implemented using the in-memory [Redis](https://redis.io/) datastore. The cache is using **Write-through** methodology where it exists as a middle man between the MongoDB and a User.

This approach is defined by slow Writes and fast Reads which suits an overall Twitter architecture.

- Initially, the cache was meant to be implemented for the list of _followers_ too, but **cache invalidation** possesses a great challenge for the volatile _followers_ storage. Hence, it requires further design sessions.