### PR TITLE
feature/Add home timeline for the followers

### DIFF
--- a/twitter-replica-backend/src/cache/methods/follow.methods.js
+++ b/twitter-replica-backend/src/cache/methods/follow.methods.js
@@ -1,12 +1,21 @@
 const redisClient = require('../redis.client');
 const constants = require('../constants');
 
+exports.getTimelineSet = (usernamePrefix) => {
+  return `timeline${constants.FOLLOW_KEY_DELIM}${usernamePrefix}`;
+};
+
 exports.getFollowingSet = (usernamePrefix) => {
   return `following${constants.FOLLOW_KEY_DELIM}${usernamePrefix}`;
 };
 
 exports.getFollowerSet = (usernamePrefix) => {
   return `followers${constants.FOLLOW_KEY_DELIM}${usernamePrefix}`;
+};
+
+exports.addTweetToTimeline = async (user, timestamp, tweet) => {
+  const timelineSet = this.getTimelineSet(user);
+  await redisClient.zaddAsync(timelineSet, timestamp, tweet);
 };
 
 exports.addFollowing = async (user, timestamp, userToFollowData) => {
@@ -19,6 +28,11 @@ exports.addFollower = async (user, timestamp, followerData) => {
   await redisClient.zaddAsync(followerSet, timestamp, followerData);
 };
 
+exports.removeTimeline = async (user) => {
+  const timelineSet = this.getTimelineSet(user);
+  await redisClient.delAsync(timelineSet);
+};
+
 exports.removeFollowing = async (user, userToRemoveData) => {
   const followingSet = this.getFollowingSet(user);
   await redisClient.zremAsync(followingSet, userToRemoveData);
@@ -27,6 +41,17 @@ exports.removeFollowing = async (user, userToRemoveData) => {
 exports.removeFollower = async (user, userToRemoveData) => {
   const followerSet = this.getFollowerSet(user);
   await redisClient.zremAsync(followerSet, userToRemoveData);
+};
+
+exports.getTimeline = async (user) => {
+  const timelineSet = this.getTimelineSet(user);
+  const timelineSetExists = await redisClient.existsAsync(timelineSet);
+  let timeline = null;
+  if (timelineSetExists) {
+    timeline = await redisClient.zrevrangeAsync([timelineSet, 0, -1]);
+    timeline = timeline.map((tweet) => JSON.parse(tweet));
+  }
+  return timeline;
 };
 
 exports.getFollowingUsers = async (user) => {

--- a/twitter-replica-backend/src/controllers/post.controller.js
+++ b/twitter-replica-backend/src/controllers/post.controller.js
@@ -39,11 +39,13 @@ exports.getPosts = asyncHandler(async (req, res) => {
 });
 
 exports.createPost = asyncHandler(async (req, res) => {
+  const creationTime = Math.floor(+Date.now() / 1000);
   const post = new Post({
     content: req.body.content,
     mediaPath: req.file.location,
     creatorId: req.userData.id,
     creatorUsernamePrefix: req.userData.usernamePrefix,
+    creationTime: creationTime,
   });
   try {
     const ret = await post.save();

--- a/twitter-replica-backend/src/models/post.model.js
+++ b/twitter-replica-backend/src/models/post.model.js
@@ -12,6 +12,7 @@ const postSchema = new mongoose.Schema({
     type: String,
     require: true,
   },
+  creationTime: { type: Number },
 });
 
 mongoose.model('Post', postSchema);

--- a/twitter-replica-backend/src/routes/api/friendship.js
+++ b/twitter-replica-backend/src/routes/api/friendship.js
@@ -3,6 +3,12 @@ const controllerFacade = require('../../controllers');
 const auth = require('../../middleware/auth');
 
 router.get(
+  '/timeline',
+  auth,
+  controllerFacade.friendshipController.getTimeline
+);
+
+router.get(
   '/following',
   auth,
   controllerFacade.friendshipController.getFollowing

--- a/twitter-replica-ui/apps/twitter-replica/src/app/app.module.ts
+++ b/twitter-replica-ui/apps/twitter-replica/src/app/app.module.ts
@@ -8,6 +8,7 @@ import { BrowserAnimationsModule } from '@angular/platform-browser/animations';
 import { TwitterCoreModule } from '@twitter-replica/core';
 import { TwitterAuthModule } from '@twitter-replica/auth';
 import { TwitterPostModule } from '@twitter-replica/post';
+import { TwitterFriendshipModule } from '@twitter-replica/friendship';
 
 @NgModule({
   declarations: [AppComponent],
@@ -18,6 +19,7 @@ import { TwitterPostModule } from '@twitter-replica/post';
     TwitterCoreModule,
     TwitterAuthModule,
     TwitterPostModule,
+    TwitterFriendshipModule,
   ],
   providers: [],
   bootstrap: [AppComponent],

--- a/twitter-replica-ui/libs/twitter-core/src/lib/http-services/fan-out.service.ts
+++ b/twitter-replica-ui/libs/twitter-core/src/lib/http-services/fan-out.service.ts
@@ -1,9 +1,8 @@
-import { Injectable } from '@angular/core';
+import { Injectable, ComponentFactoryResolver } from '@angular/core';
 import { HttpClient } from '@angular/common/http';
 import { Subject } from 'rxjs';
-import { cloneDeep } from 'lodash';
 import { URL } from './urls';
-import { FollowModel } from '../models';
+import { FollowModel, TweetTimelineModel } from '../models';
 
 @Injectable({
   providedIn: 'root',
@@ -14,10 +13,19 @@ export class FanOutService {
   // Subjects
   private followingUsersListener = new Subject<FollowModel[]>();
   private followersListener = new Subject<FollowModel[]>();
+  private timelineListener = new Subject<TweetTimelineModel[]>();
+
+  getTimeline() {
+    this.httpClient
+      .get<TweetTimelineModel[]>(`${URL.GET_TIMELINE}`)
+      .subscribe((tweets: TweetTimelineModel[]) => {
+        this.timelineListener.next(tweets);
+      });
+  }
 
   getFollowingUsers() {
     this.httpClient
-      .get<FollowModel[]>(`${URL.FOLLOWING_USERS}`)
+      .get<FollowModel[]>(`${URL.GET_FOLLOWING_USERS}`)
       .subscribe((usersToFollow: FollowModel[]) => {
         this.followingUsersListener.next(usersToFollow);
       });
@@ -25,7 +33,7 @@ export class FanOutService {
 
   getFollowers() {
     this.httpClient
-      .get<FollowModel[]>(`${URL.FOLLOWER_USERS}`)
+      .get<FollowModel[]>(`${URL.GET_FOLLOWER_USERS}`)
       .subscribe((followers: FollowModel[]) => {
         this.followersListener.next(followers);
       });
@@ -53,5 +61,9 @@ export class FanOutService {
 
   getFollowersListener() {
     return this.followersListener.asObservable();
+  }
+
+  getTimelineListener() {
+    return this.timelineListener.asObservable();
   }
 }

--- a/twitter-replica-ui/libs/twitter-core/src/lib/http-services/urls.ts
+++ b/twitter-replica-ui/libs/twitter-core/src/lib/http-services/urls.ts
@@ -27,6 +27,7 @@ export namespace URL {
   export const FRIENDSHIPS = `${API}/friendships`;
   export const FOLLOW_USER = `${FRIENDSHIPS}/follow`;
   export const UNFOLLOW_USER = `${FRIENDSHIPS}/unfollow`;
-  export const FOLLOWING_USERS = `${FRIENDSHIPS}/following`;
-  export const FOLLOWER_USERS = `${FRIENDSHIPS}/follower`;
+  export const GET_FOLLOWING_USERS = `${FRIENDSHIPS}/following`;
+  export const GET_FOLLOWER_USERS = `${FRIENDSHIPS}/follower`;
+  export const GET_TIMELINE = `${FRIENDSHIPS}/timeline`;
 }

--- a/twitter-replica-ui/libs/twitter-core/src/lib/models/fan-out/index.ts
+++ b/twitter-replica-ui/libs/twitter-core/src/lib/models/fan-out/index.ts
@@ -1,1 +1,2 @@
 export * from './follow.model';
+export * from './timeline-tweet.model';

--- a/twitter-replica-ui/libs/twitter-core/src/lib/models/fan-out/timeline-tweet.model.ts
+++ b/twitter-replica-ui/libs/twitter-core/src/lib/models/fan-out/timeline-tweet.model.ts
@@ -1,0 +1,7 @@
+export interface TweetTimelineModel {
+  name: string;
+  username: string;
+  avatar: string;
+  content: string;
+  mediaPath: string;
+}

--- a/twitter-replica-ui/libs/twitter-core/src/lib/models/posts/backend-post.model.ts
+++ b/twitter-replica-ui/libs/twitter-core/src/lib/models/posts/backend-post.model.ts
@@ -5,4 +5,5 @@ export interface BackendPostModel {
   mediaPath: string;
   creatorId: string;
   creatorUsernamePrefix: string;
+  creationTime: number;
 }

--- a/twitter-replica-ui/libs/twitter-friendship/src/lib/friendships/timeline/timeline.component.html
+++ b/twitter-replica-ui/libs/twitter-friendship/src/lib/friendships/timeline/timeline.component.html
@@ -1,0 +1,15 @@
+<mat-card class="tweet" *ngFor="let tweet of timeline">
+  <mat-card-header>
+    <div mat-card-avatar>
+      <img mat-card-avatar [src]="tweet.avatar" alt="No avatar image" />
+    </div>
+    <mat-card-title>{{ tweet.name }}</mat-card-title>
+    <mat-card-subtitle>@{{ tweet.username }}</mat-card-subtitle>
+  </mat-card-header>
+  <mat-card-content>
+    <p>
+      {{ tweet.content }}
+    </p>
+  </mat-card-content>
+  <img mat-card-image [src]="tweet.mediaPath" alt="No image available" />
+</mat-card>

--- a/twitter-replica-ui/libs/twitter-friendship/src/lib/friendships/timeline/timeline.component.scss
+++ b/twitter-replica-ui/libs/twitter-friendship/src/lib/friendships/timeline/timeline.component.scss
@@ -1,0 +1,8 @@
+.mat-tab-group {
+  margin-bottom: 48px;
+}
+.tweet {
+  width: 400px;
+  margin: 0 auto;
+  width: 50%;
+}

--- a/twitter-replica-ui/libs/twitter-friendship/src/lib/friendships/timeline/timeline.component.spec.ts
+++ b/twitter-replica-ui/libs/twitter-friendship/src/lib/friendships/timeline/timeline.component.spec.ts
@@ -1,0 +1,24 @@
+import { async, ComponentFixture, TestBed } from '@angular/core/testing';
+
+import { TimelineComponent } from './timeline.component';
+
+describe('HeaderComponent', () => {
+  let component: TimelineComponent;
+  let fixture: ComponentFixture<TimelineComponent>;
+
+  beforeEach(async(() => {
+    TestBed.configureTestingModule({
+      declarations: [TimelineComponent],
+    }).compileComponents();
+  }));
+
+  beforeEach(() => {
+    fixture = TestBed.createComponent(TimelineComponent);
+    component = fixture.componentInstance;
+    fixture.detectChanges();
+  });
+
+  it('should create', () => {
+    expect(component).toBeTruthy();
+  });
+});

--- a/twitter-replica-ui/libs/twitter-friendship/src/lib/friendships/timeline/timeline.component.ts
+++ b/twitter-replica-ui/libs/twitter-friendship/src/lib/friendships/timeline/timeline.component.ts
@@ -1,0 +1,29 @@
+import { Component, OnInit, OnDestroy } from '@angular/core';
+import { Subscription } from 'rxjs';
+import { FanOutService, TweetTimelineModel } from 'libs/twitter-core/src';
+
+@Component({
+  selector: 'twitter-timeline',
+  templateUrl: './timeline.component.html',
+  styleUrls: ['./timeline.component.scss'],
+})
+export class TimelineComponent implements OnInit, OnDestroy {
+  constructor(private readonly fanOutService: FanOutService) {}
+  timeline: TweetTimelineModel[] = [];
+
+  // Subscriptions
+  followingUsersSubs: Subscription;
+
+  ngOnInit() {
+    this.followingUsersSubs = this.fanOutService
+      .getTimelineListener()
+      .subscribe((tweets: TweetTimelineModel[]) => {
+        this.timeline = tweets;
+      });
+    this.fanOutService.getTimeline();
+  }
+
+  ngOnDestroy() {
+    this.followingUsersSubs.unsubscribe();
+  }
+}

--- a/twitter-replica-ui/libs/twitter-friendship/src/lib/twitter-friendship.module.ts
+++ b/twitter-replica-ui/libs/twitter-friendship/src/lib/twitter-friendship.module.ts
@@ -4,6 +4,7 @@ import { RouterModule, Route } from '@angular/router';
 import { MaterialModule } from '../../../material.module';
 import { ReactiveFormsModule } from '@angular/forms';
 
+import { TimelineComponent } from './friendships/timeline/timeline.component';
 import { TwitterFollowComponent } from './friendships/follow/follow.component';
 
 export const TwitterFriendshipRoutes: Route[] = [
@@ -19,7 +20,7 @@ export const TwitterFriendshipRoutes: Route[] = [
 
 @NgModule({
   imports: [CommonModule, RouterModule, MaterialModule, ReactiveFormsModule],
-  declarations: [TwitterFollowComponent],
-  exports: [TwitterFollowComponent],
+  declarations: [TwitterFollowComponent, TimelineComponent],
+  exports: [TwitterFollowComponent, TimelineComponent],
 })
 export class TwitterFriendshipModule {}

--- a/twitter-replica-ui/libs/twitter-user/src/lib/twitter-user.module.ts
+++ b/twitter-replica-ui/libs/twitter-user/src/lib/twitter-user.module.ts
@@ -8,6 +8,7 @@ import {
   TwitterUserHomepageComponent,
   TwitterUserProfileUpdateComponent,
 } from './user-homepage/user-homepage.component';
+import { TwitterFriendshipModule } from '@twitter-replica/friendship';
 import { TwitterPostModule } from '@twitter-replica/post';
 
 export const TwitterUserRoutes: Route[] = [
@@ -22,8 +23,9 @@ export const TwitterUserRoutes: Route[] = [
     CommonModule,
     RouterModule,
     MaterialModule,
-    TwitterPostModule,
     ReactiveFormsModule,
+    TwitterFriendshipModule,
+    TwitterPostModule,
   ],
   declarations: [
     TwitterUserHomepageComponent,

--- a/twitter-replica-ui/libs/twitter-user/src/lib/user-homepage/user-homepage.component.html
+++ b/twitter-replica-ui/libs/twitter-user/src/lib/user-homepage/user-homepage.component.html
@@ -41,4 +41,18 @@
     </div>
   </mat-card-content>
 </mat-card>
-<twitter-post-list></twitter-post-list>
+<!-- Feed -->
+<div *ngIf="authStatus && userId == currentUser.id">
+  <mat-tab-group mat-align-tabs="center">
+    <mat-tab label="Timeline">
+      <twitter-timeline></twitter-timeline>
+    </mat-tab>
+    <mat-tab label="My feed">
+      <twitter-post-list></twitter-post-list>
+    </mat-tab>
+  </mat-tab-group>
+</div>
+
+<div *ngIf="!authStatus || userId != currentUser.id">
+  <twitter-post-list></twitter-post-list>
+</div>

--- a/twitter-replica-ui/libs/twitter-user/src/lib/user-homepage/user-homepage.component.ts
+++ b/twitter-replica-ui/libs/twitter-user/src/lib/user-homepage/user-homepage.component.ts
@@ -80,7 +80,9 @@ export class TwitterUserHomepageComponent implements OnInit, OnDestroy {
           users.filter((user) => user.usernamePrefix === this.usernamePrefix)
             .length > 0;
       });
-    this.fanOutService.getFollowingUsers();
+    if (this.authStatus) {
+      this.fanOutService.getFollowingUsers();
+    }
 
     this.form = new FormGroup({
       coverImage: new FormControl(null, {


### PR DESCRIPTION
Add a home timeline for the tweets that the user is following.

Frontend:
- Add a _timeline_ component.
- Add a _timeline_ model.
- Add Tabs for the switch between the home timeline and the user's personal feed.

Backend:
- Add a _timeline_ route.
- Add a _timeline_ data caching. Cached data is removed on a new _follow_ and _unfollow_.
- Update _Post_ model with an extra attribute: **creationTime**. For the Timeline structuring using a Unix time.